### PR TITLE
Remove trailing `/` from `getGitHubRepoDocsRootPathURL`

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/hello-dolly/src/ExtensionStaticHelpers.php
+++ b/layers/GatoGraphQLForWP/plugins/hello-dolly/src/ExtensionStaticHelpers.php
@@ -28,6 +28,6 @@ class ExtensionStaticHelpers
 
     public static function getGitHubRepoDocsRootPathURL(): string
     {
-        return static::getGitHubRepoDocsRootURL() . '/' . static::getGitHubRepoDocsBranchOrTag() . '/layers/GatoGraphQLForWP/plugins/hello-dolly/';
+        return static::getGitHubRepoDocsRootURL() . '/' . static::getGitHubRepoDocsBranchOrTag() . '/layers/GatoGraphQLForWP/plugins/hello-dolly';
     }
 }


### PR DESCRIPTION
https://github.com/GatoGraphQL/GatoGraphQL/pull/2552