### PR TITLE
Only initialize text domain after validating the plugin can be initialized

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/hello-dolly/gatographql-hello-dolly.php
+++ b/layers/GatoGraphQLForWP/plugins/hello-dolly/gatographql-hello-dolly.php
@@ -24,13 +24,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-add_action('init', function (): void {
-    if (!class_exists(\PoPIncludes\GatoGraphQL\Startup::class)) {
-        return;
-    }
-    \PoPIncludes\GatoGraphQL\Startup::loadTextdomainWithFallback(__DIR__ . '/languages/', basename(__FILE__, '.php') . '-');
-}, PHP_INT_MIN);
-
 /**
  * Create and set-up the extension
  */
@@ -159,6 +152,13 @@ add_action(
             // Load Composer’s autoloader
             require_once(__DIR__ . '/vendor/autoload.php');
         }
+
+        add_action('init', function (): void {
+            if (!class_exists(\PoPIncludes\GatoGraphQL\Startup::class)) {
+                return;
+            }
+            \PoPIncludes\GatoGraphQL\Startup::loadTextdomainWithFallback(__DIR__ . '/languages/', basename(__FILE__, '.php') . '-');
+        }, PHP_INT_MIN);
 
         /**
          * The commit hash is added to the plugin version 

--- a/layers/GatoGraphQLForWP/plugins/hello-dolly/gatographql-hello-dolly.php
+++ b/layers/GatoGraphQLForWP/plugins/hello-dolly/gatographql-hello-dolly.php
@@ -154,9 +154,6 @@ add_action(
         }
 
         add_action('init', function (): void {
-            if (!class_exists(\PoPIncludes\GatoGraphQL\Startup::class)) {
-                return;
-            }
             \PoPIncludes\GatoGraphQL\Startup::loadTextdomainWithFallback(__DIR__ . '/languages/', basename(__FILE__, '.php') . '-');
         }, PHP_INT_MIN);
 


### PR DESCRIPTION
Move the `add_action('init', …)` text-domain loading so it runs only after the plugin's initialization validations pass, rather than unconditionally on plugin load.

The text-domain block is relocated from the top of the plugin entry file to just before the `$commitHash = null;` line, i.e. after the checks that confirm the plugin can be initialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)